### PR TITLE
make license in sidebar relative to site base url

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -21,7 +21,7 @@
       {{ with .Site.Params.twitter }}<li class="sidebar-nav-item"><a href="{{ . }}">Twitter</a></li>{{ end }}
     </ul>
 
-    <p>Copyright &copy; {{ .Now.Format "2006" }} <a href="/license">License</a><br/>
+    <p>Copyright &copy; {{ .Now.Format "2006" }} <a href="{{ .Site.BaseUrl }}/license">License</a><br/>
        Powered by <a href="http://hugo.spf13.com">Hugo</a> and <a href="https://github.com/zyro/hyde-x">Hyde-X</a></p>
   </div>
 </div>


### PR DESCRIPTION
If a site is based off a sub-directory http://site/path/ the license will not be linked correctly
