### PR TITLE
Making inclusion of partial templates use the 'partial' function so that they can be overridden.

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,4 +1,4 @@
-{{ template "theme/partials/head.html" . }}
+{{ partial "head.html" . }}
 <div class="content container">
   <ul class="posts">
   {{ range .Data.Pages }}
@@ -6,4 +6,4 @@
   {{ end }}
   </ul>
 </div>
-{{ template "theme/partials/foot.html" . }}
+{{ partial "foot.html" . }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,8 +1,8 @@
-{{ template "theme/partials/head.html" . }}
+{{ partial "head.html" . }}
 <div class="content container">
   <div class="post">
     <h1>{{ .Title }}</h1>
     {{ .Content }}
   </div>
 </div>
-{{ template "theme/partials/foot.html" . }}
+{{ partial "foot.html" . }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,4 +1,4 @@
-{{ template "theme/partials/head.html" . }}
+{{ partial "head.html" . }}
 <div class="content container">
   <div class="posts">
     {{ range .Data.Pages }}{{ if eq .Section "post" }}
@@ -25,4 +25,4 @@ var disqus_shortname = {{ . }};
 }());
 </script>
 {{ end }}
-{{ template "theme/partials/foot.html" . }}
+{{ partial "foot.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -30,4 +30,4 @@
   {{ with .Site.Params.googleAuthorship }}<link rel="author" href="http://plus.google.com/{{ . }}">{{ end }}
 </head>
 <body{{ with .Site.Params.theme }} class="{{ . }}"{{ end }}>
-{{ template "theme/partials/sidebar.html" . }}
+{{ partial "sidebar.html" . }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,4 +1,4 @@
-{{ template "theme/partials/head.html" . }}
+{{ partial "head.html" . }}
 <div class="content container">
   <div class="post">
     <h1>{{ .Title }}</h1>
@@ -32,4 +32,4 @@ var disqus_shortname = {{ . }};
 <noscript>Please enable JavaScript to view the <a href="http://disqus.com/?ref_noscript">comments powered by Disqus.</a></noscript>
 <a href="http://disqus.com" class="dsq-brlink">comments powered by <span class="logo-disqus">Disqus</span></a>
 {{ end }}
-{{ template "theme/partials/foot.html" . }}
+{{ partial "foot.html" . }}


### PR DESCRIPTION
Hi - thank you for porting this theme to Hugo!

This patch updates the partial template inclusion to the [recommended method from version 0.12](http://gohugo.io/templates/partials/) so that it can do overrides from the local layout. 
Automated change with:

```
 find -name '*.html' |xargs grep -l theme/partials |xargs -L1 sed -i "s/template \"theme\/partials\//partial \"/g"
```
