### PR TITLE
google fonts: use https instead of http

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,7 +16,7 @@
   <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/hyde-overrides.css">
   <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/hyde-x.css">
   {{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/highlight/{{ .Site.Params.highlight }}.css">{{ end }}
-  <link rel="stylesheet" href="http://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-144-precomposed.png">


### PR DESCRIPTION
When used on an https-only site, Firefox 35 blocked the google fonts
stylesheet include because it was linked as http instead of https

fixes my just-filed issue #8