### PR TITLE
add icons for twitter/facebook/etc. links

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -17,6 +17,7 @@
   <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/hyde-x.css">
   {{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/highlight/{{ .Site.Params.highlight }}.css">{{ end }}
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
+  <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="/apple-touch-icon-144-precomposed.png">

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -14,11 +14,13 @@
     </ul>
 
     <ul class="sidebar-nav">
-      {{ with .Site.Params.github }}<li class="sidebar-nav-item"><a href="{{ . }}">GitHub</a></li>{{ end }}
-      {{ with .Site.Params.linkedin }}<li class="sidebar-nav-item"><a href="{{ . }}">LinkedIn</a></li>{{ end }}
-      {{ with .Site.Params.googleplus }}<li class="sidebar-nav-item"><a href="{{ . }}">Google+</a></li>{{ end }}
-      {{ with .Site.Params.facebook }}<li class="sidebar-nav-item"><a href="{{ . }}">Facebook</a></li>{{ end }}
-      {{ with .Site.Params.twitter }}<li class="sidebar-nav-item"><a href="{{ . }}">Twitter</a></li>{{ end }}
+      <li class="sidebar-nav-item">
+      {{ with .Site.Params.github }}<a href="{{ . }}"><i class="fa fa-github-square fa-3x"></i></a>{{ end }}
+      {{ with .Site.Params.linkedin }}<a href="{{ . }}"><i class="fa fa-linkedin-square fa-3x"></i></a>{{ end }}
+      {{ with .Site.Params.googleplus }}<a href="{{ . }}"><i class="fa fa-google-plus-square fa-3x"></i></a>{{ end }}
+      {{ with .Site.Params.facebook }}<a href="{{ . }}"><i class="fa fa-facebook-square fa-3x"></i></a>{{ end }}
+      {{ with .Site.Params.twitter }}<a href="{{ . }}"><i class="fa fa-twitter-square fa-3x"></i></a>{{ end }}
+      </li>
     </ul>
 
     <p>Copyright &copy; {{ .Now.Format "2006" }} <a href="{{ .Site.BaseUrl }}/license">License</a><br/>


### PR DESCRIPTION
These icons are grabbed through FontAwesome, which means they match the
color of the text around them. Much easier on the eyes then text links! Here's an example of how it looks:

![example](http://i.imgur.com/wSFiwYm.jpg)

I don't know what that strange doubling effect on the large text is; it only shows when I'm looking at it on my iPad. I think that's rendered through the google font API so I presume it's an issue with them.