### PR TITLE
Url -> URL

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -3,7 +3,7 @@
   <div class="post">
     <h1>404 Not Found</h1>
     <p>What you're looking for isn't here, sorry!</p>
-    <p><a href="{{ .Site.BaseUrl }}">&larr; Click here to go back home</a></p>
+    <p><a href="{{ .Site.BaseURL }}">&larr; Click here to go back home</a></p>
   </div>
 </div>
 {{ partial "foot.html" . }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,8 +5,8 @@
     <li><a href="{{ .Permalink }}">{{ .Title }}</a>
     {{ if isset .Params "categories" }}
     &middot;
-    {{ $baseUrl := .Site.BaseUrl }}
-    {{ range .Params.categories }}<a class="label" href="{{ $baseUrl }}/categories/{{ . | urlize }}">{{ . }}</a>{{ end }}
+    {{ $baseURL := .Site.BaseURL }}
+    {{ range .Params.categories }}<a class="label" href="{{ $baseURL }}/categories/{{ . | urlize }}">{{ . }}</a>{{ end }}
     {{ end }}</span>
     &middot; <time>{{ .Date.Format "Jan 2, 2006" }}</time></li>
   {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,7 +10,7 @@
       <span class="post-date">{{ .Date.Format "Jan 2, 2006" }} &middot; {{ .ReadingTime }} minute read{{ if .Site.DisqusShortname }} &middot; <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
       {{ if isset .Params "categories" }}
       <br/>
-      {{ $baseUrl := .Site.BaseUrl }}
+      {{ $baseUrl := .Site.BaseURL }}
       {{ range .Params.categories }}<a class="label" href="{{ $baseUrl }}/categories/{{ . | urlize }}">{{ . }}</a>{{ end }}
       {{ end }}</span>
       <p>{{ .Description }}</p>

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -1,4 +1,4 @@
-{{ if isset .Site.Params "highlight" }}<script src="{{ .Site.BaseUrl }}/js/highlight.pack.js"></script>
+{{ if isset .Site.Params "highlight" }}<script src="{{ .Site.BaseURL }}/js/highlight.pack.js"></script>
 <script>hljs.initHighlightingOnLoad();</script>{{ end }}
 {{ with .Site.Params.googleAnalytics }}
 <script>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,12 +10,12 @@
   <title>{{ .Title }} &middot; {{ .Site.Author.name }}</title>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/poole.css">
-  <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/hyde.css">
-  <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/poole-overrides.css">
-  <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/hyde-overrides.css">
-  <link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/hyde-x.css">
-  {{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ .Site.BaseUrl }}/css/highlight/{{ .Site.Params.highlight }}.css">{{ end }}
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/poole.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/hyde.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/poole-overrides.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/hyde-overrides.css">
+  <link rel="stylesheet" href="{{ .Site.BaseURL }}/css/hyde-x.css">
+  {{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ .Site.BaseURL }}/css/highlight/{{ .Site.Params.highlight }}.css">{{ end }}
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
 

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -7,9 +7,9 @@
     </div>
 
     <ul class="sidebar-nav">
-      <li class="sidebar-nav-item"><a href="{{ .Site.BaseUrl }}/">Blog</a></li>
+      <li class="sidebar-nav-item"><a href="{{ .Site.BaseURL }}/">Blog</a></li>
       {{ range .Site.Menus.main }}
-      <li class="sidebar-nav-item"><a href="{{ .Url }}">{{ .Name }}</a></li>
+      <li class="sidebar-nav-item"><a href="{{ .URL }}">{{ .Name }}</a></li>
       {{end}}
     </ul>
 
@@ -24,7 +24,7 @@
       </li>
     </ul>
 
-    <p>Copyright &copy; {{ .Now.Format "2006" }} <a href="{{ .Site.BaseUrl }}/license">License</a><br/>
+    <p>Copyright &copy; {{ .Now.Format "2006" }} <a href="{{ .Site.BaseURL }}/license">License</a><br/>
        Powered by <a href="http://gohugo.io">Hugo</a> and <a href="https://github.com/zyro/hyde-x">Hyde-X</a></p>
   </div>
 </div>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -5,7 +5,7 @@
     <span class="post-date">{{ .Date.Format "Jan 2, 2006" }} &middot; {{ .ReadingTime }} minute read{{ if .Site.DisqusShortname }} &middot; <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
     {{ if isset .Params "categories" }}
     <br/>
-    {{ $baseUrl := .Site.BaseUrl }}
+    {{ $baseUrl := .Site.BaseURL }}
     {{ range .Params.categories }}<a class="label" href="{{ $baseUrl }}/categories/{{ . | urlize }}">{{ . }}</a>{{ end }}
     {{ end }}</span>
     {{ .Content }}


### PR DESCRIPTION
This removes multiple 0.15 warnings:

Site's .BaseUrl is deprecated and will be removed in Hugo 0.15. Use .BaseURL instead.
MenuEntry's .Url is deprecated and will be removed in Hugo 0.15. Use .URL instead.