### PR TITLE
Add support for summaries.

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,9 +14,12 @@
       {{ end }}</span>
       {{ if eq .Site.Params.truncate false }}
       {{ .Content }}
-      {{ else }}
+      {{ else if .Description }}
       <p>{{ .Description }}</p>
       <a href="{{ .Permalink }}">Read On &rarr;</a>
+      {{ else }}
+      {{ .Summary }}
+      {{ if .Truncated }}<a href="{{ .Permalink }}">Read On &rarr;</a>{{ end }}
       {{ end }}
     </div>
     {{ end }}


### PR DESCRIPTION
Currently when you set your `config.toml` to truncate the posts with:

```toml
[params]
	truncate = true
```

it uses the `Description` property; but I don't have it on my posts at all... instead I use [summaries](http://gohugo.io/content/summaries/), so this patch adds support for them (while still supporting the `Description` property).