### PR TITLE
use name as title for gravatar

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,7 +1,10 @@
 <div class="sidebar">
   <div class="container sidebar-sticky">
     <div class="sidebar-about">
-      {{ with .Site.Params.gravatarHash }}<img src="https://www.gravatar.com/avatar/{{ . }}?s=200" alt="gravatar">{{ end }}
+      {{ if isset .Site.Params "gravatarHash" }}
+        <img src="https://www.gravatar.com/avatar/{{ .Site.Params.gravatarHash }}?s=200"
+             alt="gravatar" title="{{ .Site.Author.name }}">
+      {{ end }}
       <h1>{{ .Site.Author.name }}</h1>
       {{ with .Site.Params.tagline }}<p class="lead">{{ . | markdownify }}</p>{{ end }}
     </div>


### PR DESCRIPTION
Another tweak - and I didn't include it here as I'm not sure your opinion, but I'm trying to decide if it makes sense to have the Gravatar and/or text name be links (just to the homepage), and maybe hiding the top menu link if desired. LMK if you think it's worth having configuration for those sorts of things or if that's getting to be overkill, thanks!