### PR TITLE
sidebar name override, gravatar name title

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,12 @@ paginate = 10
     # Other social-like sidebar links
     rss = false  # switch to true to enable RSS icon link
     flattr = ""  # populate with your flattr uid
+
+    # These optional settings allow deeper customization of the template
+    # You should only define and set values in this array if you want to
+    # completely replace the related default values
+    [params.overrides]
+        sidebarname = ""  # setting this would blank out the sidebar name
 ```
 
 ### Built-in colour themes

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -1,8 +1,13 @@
 <div class="sidebar">
   <div class="container sidebar-sticky">
     <div class="sidebar-about">
-      {{ with .Site.Params.gravatarHash }}<img src="https://www.gravatar.com/avatar/{{ . }}?s=200" alt="gravatar">{{ end }}
-      <h1>{{ .Site.Author.name }}</h1>
+      {{ if isset .Site.Params "gravatarHash" }}
+      <img src="https://www.gravatar.com/avatar/{{ .Site.Params.gravatarHash }}?s=200" alt="gravatar" title="{{ .Site.Author.name }}">
+      {{ end }}
+      <h1>
+        {{ if isset .Site.Params.overrides "sidebarname" }}{{ .Site.Params.overrides.sidebarname }}
+        {{ else }}{{ .Site.Author.name }}{{ end }}
+      </h1>
       {{ with .Site.Params.tagline }}<p class="lead">{{ . | markdownify }}</p>{{ end }}
     </div>
 


### PR DESCRIPTION
Revisiting that earlier pull request - now replacing the sidebar name is in an optional sub-array of "override" parameters. This could obviously be further fleshed out to override other parts of the template as desired, but I thought I'd get your thoughts first. I am also still including the `title="{{ .Site.Author.name }}"` for the Gravatar, which I think is a sensible default. Thanks!