### PR TITLE
allow custom CSS file, hiding read time, update analytics, remove authorship

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ paginate = 10
     defaultDescription = "Your default page description"
     defaultKeywords = "your,default,page,keywords"
 
-    # Show estimated reading time for posts.
+    # Hide estimated reading time for posts.
     # Default (if omitted) is false.
     hideReadingTime = false
 

--- a/README.md
+++ b/README.md
@@ -88,6 +88,9 @@ paginate = 10
     # Check the static/css/highlight directory for options.
     highlight = "sunburst"
 
+    # Optional additional custom CSS file URL, will override other styles
+    customCSS = ""
+
     # Displays under the author name in the sidebar, keep it short.
     # You can use markdown here.
     tagline = "Your favourite quote or soundbite."

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ paginate = 10
     defaultDescription = "Your default page description"
     defaultKeywords = "your,default,page,keywords"
 
+    # Show estimated reading time for posts.
+    # Default (if omitted) is false.
+    hideReadingTime = false
+
     # Changes sidebar background and link/accent colours.
     # See below for more colour options.
     # This also works: "theme-base-08 layout-reverse", or just "layout-reverse".
@@ -88,7 +92,7 @@ paginate = 10
     # Check the static/css/highlight directory for options.
     highlight = "sunburst"
 
-    # Optional additional custom CSS file URL, will override other styles
+    # Optional additional custom CSS file URL, will override other styles.
     customCSS = ""
 
     # Displays under the author name in the sidebar, keep it short.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,6 @@ paginate = 10
     home = "Blog"
 
     # Metadata used to drive integrations.
-    googleAuthorship = "Your Google+ profile ID"
     googleAnalytics = "Your Google Analytics tracking code"
     gravatarHash = "MD5 hash of your Gravatar email address"
 
@@ -147,7 +146,6 @@ Hyde-X provides 8 built-in colour themes by default, with the option to define m
 * Disqus integration: comment counts listed under blog entry names in post list, comments displayed at the bottom of each post.
 * Gravatar image in sidebar.
 * Google Analytics integration.
-* Google Authorship metadata.
 * Sidebar link layout and footer format changes.
 * Blog post list now contains only the post description, not the full contents.
 * Paginated blog listing.

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,7 +1,7 @@
 {{ partial "head.html" . }}
 <div class="content container">
   <div class="post">
-    <h1>{{ .Title }}</h1>
+    <h1 class="post-title">{{ .Title }}</h1>
     {{ .Content }}
   </div>
 </div>

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -7,7 +7,7 @@
       <h1 class="post-title">
         <a href="{{ .Permalink }}">{{ .Title }}</a>
       </h1>
-      <span class="post-date">{{ .Date.Format "Jan 2, 2006" }} &middot; {{ .ReadingTime }} minute read{{ if .Site.DisqusShortname }} &middot; <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
+      <span class="post-date">{{ .Date.Format "Jan 2, 2006" }}{{ if not .Site.Params.hideReadingTime }} &middot; {{ .ReadingTime }} minute read{{ end }}{{ if .Site.DisqusShortname }} &middot; <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
       {{ if isset .Params "categories" }}
       <br/>
       {{ range .Params.categories }}<a class="label" href="{{ "/categories/" | absURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -1,12 +1,4 @@
 {{ if isset .Site.Params "highlight" }}<script src="{{ "/js/highlight.pack.js" | absURL }}"></script>
 <script>hljs.initHighlightingOnLoad();</script>{{ end }}
-{{ with .Site.Params.googleAnalytics }}
-<script>
-  var _gaq=[['_setAccount','{{ . }}'],['_trackPageview']];
-  (function(d,t){var g=d.createElement(t),s=d.getElementsByTagName(t)[0];
-  g.src=('https:'==location.protocol?'//ssl':'//www')+'.google-analytics.com/ga.js';
-  s.parentNode.insertBefore(g,s)}(document,'script'));
-</script>
-{{ end }}
 </body>
 </html>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,6 +18,7 @@
   {{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ "/css/highlight/" | absURL }}{{ .Site.Params.highlight }}.css">{{ end }}
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
+  {{ with .Site.Params.customCSS }}<link rel="stylesheet" href="{{ . }}">{{ end }}
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ "/touch-icon-144-precomposed.png" | absURL }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -31,7 +31,16 @@
 
   <meta name="description" content="{{ if ne .Description "" }}{{ .Description }}{{ else }}{{ .Site.Params.defaultDescription }}{{ end }}">
   <meta name="keywords" content="{{ range $index, $element := .Keywords }}{{ if gt $index 0 }},{{ end }}{{ . }}{{ else }}{{ .Site.Params.defaultKeywords }}{{ end }}">
-  {{ with .Site.Params.googleAuthorship }}<link rel="author" href="http://plus.google.com/{{ . }}">{{ end }}
+  {{ with .Site.Params.googleAnalytics }}
+  <script>
+    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+
+    ga('create', '{{ . }}', 'auto');
+    ga('send', 'pageview');
+  </script>
 </head>
 <body{{ with .Site.Params.theme }} class="{{ . }}"{{ end }}>
 {{ partial "sidebar.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -41,6 +41,7 @@
     ga('create', '{{ . }}', 'auto');
     ga('send', 'pageview');
   </script>
+  {{ end }}
 </head>
 <body{{ with .Site.Params.theme }} class="{{ . }}"{{ end }}>
 {{ partial "sidebar.html" . }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -2,7 +2,7 @@
 <div class="content container">
   <div class="post">
     <h1>{{ .Title }}</h1>
-    <span class="post-date">{{ .Date.Format "Jan 2, 2006" }} &middot; {{ .ReadingTime }} minute read{{ if .Site.DisqusShortname }} &middot; <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
+    <span class="post-date">{{ .Date.Format "Jan 2, 2006" }}{{ if not .Site.Params.hideReadingTime }} &middot; {{ .ReadingTime }} minute read{{ end }}{{ if .Site.DisqusShortname }} &middot; <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
     {{ if isset .Params "categories" }}
     <br/>
     {{ range .Params.categories }}<a class="label" href="{{ "/categories/" | absURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -1,7 +1,7 @@
 {{ partial "head.html" . }}
 <div class="content container">
   <div class="post">
-    <h1>{{ .Title }}</h1>
+    <h1 class="post-title">{{ .Title }}</h1>
     <span class="post-date">{{ .Date.Format "Jan 2, 2006" }}{{ if not .Site.Params.hideReadingTime }} &middot; {{ .ReadingTime }} minute read{{ end }}{{ if .Site.DisqusShortname }} &middot; <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
     {{ if isset .Params "categories" }}
     <br/>


### PR DESCRIPTION
Lets user put a CSS file in config.toml that will override other CSS files as needed. I checked Hugo docs a bit and didn't see a cleverer way to integrate arbitrary CSS - the user could override e.g. `hyde-x.css` in their own static directory, but would then have to manually copy in updates as changes are made, so I think this is more maintainable. Thanks!