### PR TITLE
Move sidebar copyright & powered-by to a partial

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -45,7 +45,6 @@
     </script></p>
     {{ end }}
 
-    <p>Copyright &copy; {{ .Now.Format "2006" }} <a href="{{ "/license/" | absURL }}">License</a><br/>
-       Powered by <a href="http://gohugo.io">Hugo</a> and <a href="https://github.com/zyro/hyde-x">Hyde-X</a></p>
+    {{ partial "sidebar/footer.html" . }}
   </div>
 </div>

--- a/layouts/partials/sidebar/footer.html
+++ b/layouts/partials/sidebar/footer.html
@@ -1,0 +1,2 @@
+<p>Copyright &copy; {{ .Now.Format "2006" }} <a href="{{ "/license/" | absURL }}">License</a><br/>
+  Powered by <a href="http://gohugo.io">Hugo</a> and <a href="https://github.com/zyro/hyde-x">Hyde-X</a></p>


### PR DESCRIPTION
I wanted to change the format of the copyright notice, using a range of years and "Some rights reserved" text in place of "License". I imagine this and possibly removing the "powered by" text (if it gets cramped 😇 ) are common wishes, so a more targeted partial seemed sensible to me.
