### PR TITLE
added the absolute url to customCSS added in Site.Params

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -18,7 +18,7 @@
   {{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ "/css/highlight/" | absURL }}{{ .Site.Params.highlight }}.css">{{ end }}
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
-  {{ with .Site.Params.customCSS }}<link rel="stylesheet" href="{{ . }}">{{ end }}
+  {{ with .Site.Params.customCSS }}<link rel="stylesheet" href="{{ . | absURL }}">{{ end }}
 
   <!-- Icons -->
   <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ "/touch-icon-144-precomposed.png" | absURL }}">


### PR DESCRIPTION
Simple fix to make sure custom CSS added via the config.toml has an absolute url.