### PR TITLE
Replace page now with now function

### DIFF
--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -45,7 +45,6 @@
     </script></p>
     {{ end }}
 
-    <p>Copyright &copy; {{ .Now.Format "2006" }} <a href="{{ "/license/" | absURL }}">License</a><br/>
-       Powered by <a href="http://gohugo.io">Hugo</a> and <a href="https://github.com/zyro/hyde-x">Hyde-X</a></p>
+    {{ partial "sidebar/footer.html" . }}
   </div>
 </div>

--- a/layouts/partials/sidebar/footer.html
+++ b/layouts/partials/sidebar/footer.html
@@ -1,0 +1,2 @@
+<p>Copyright &copy; {{ .Now.Format "2006" }} <a href="{{ "/license/" | absURL }}">License</a><br/>
+  Powered by <a href="http://gohugo.io">Hugo</a> and <a href="https://github.com/zyro/hyde-x">Hyde-X</a></p>

--- a/layouts/partials/sidebar/footer.html
+++ b/layouts/partials/sidebar/footer.html
@@ -1,2 +1,2 @@
-<p>Copyright &copy; {{ .Now.Format "2006" }} <a href="{{ "/license/" | absURL }}">License</a><br/>
-  Powered by <a href="http://gohugo.io">Hugo</a> and <a href="https://github.com/zyro/hyde-x">Hyde-X</a></p>
+<p>Copyright &copy; {{ now.Format "2006" }} <a href="{{ "/license/" | absURL }}">License</a><br/>
+       Powered by <a href="http://gohugo.io">Hugo</a> and <a href="https://github.com/zyro/hyde-x">Hyde-X</a></p>


### PR DESCRIPTION
This PR include https://github.com/zyro/hyde-x/pull/59 because that seems like a good idea and changes the same code.  

This gets rid of the following deprecation message during build.  

```
WARNING: Page's Now is deprecated and will be removed in a future release. Use now (the template func).
```