### PR TITLE
absURL was not used correctly resulting in broken links

### DIFF
--- a/layouts/404.html
+++ b/layouts/404.html
@@ -3,7 +3,7 @@
   <div class="post">
     <h1>404 Not Found</h1>
     <p>What you're looking for isn't here, sorry!</p>
-    <p><a href="{{ "/" | absURL }}">&larr; Click here to go back home</a></p>
+    <p><a href="{{ "" | absURL }}">&larr; Click here to go back home</a></p>
   </div>
 </div>
 {{ partial "foot.html" . }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,7 +5,7 @@
     <li><a href="{{ .Permalink }}">{{ .Title }}</a>
     {{ if isset .Params "categories" }}
     &middot;
-    {{ range .Params.categories }}<a class="label" href="{{ "/categories/" | absURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
+    {{ range .Params.categories }}<a class="label" href="{{ "categories/" | absURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
     {{ end }}</span>
     &middot; <time>{{ .Date.Format "Jan 2, 2006" }}</time></li>
   {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -10,7 +10,7 @@
       <span class="post-date">{{ .Date.Format "Jan 2, 2006" }}{{ if not .Site.Params.hideReadingTime }} &middot; {{ .ReadingTime }} minute read{{ end }}{{ if .Site.DisqusShortname }} &middot; <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
       {{ if isset .Params "categories" }}
       <br/>
-      {{ range .Params.categories }}<a class="label" href="{{ "/categories/" | absURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
+      {{ range .Params.categories }}<a class="label" href="{{ "categories/" | absURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
       {{ end }}</span>
       {{ if eq .Site.Params.truncate false }}
       {{ .Content }}

--- a/layouts/partials/foot.html
+++ b/layouts/partials/foot.html
@@ -1,4 +1,4 @@
-{{ if isset .Site.Params "highlight" }}<script src="{{ "/js/highlight.pack.js" | absURL }}"></script>
+{{ if isset .Site.Params "highlight" }}<script src="{{ "js/highlight.pack.js" | absURL }}"></script>
 <script>hljs.initHighlightingOnLoad();</script>{{ end }}
 </body>
 </html>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -10,19 +10,19 @@
   <title>{{ .Title }} &middot; {{ .Site.Author.name }}</title>
 
   <!-- CSS -->
-  <link rel="stylesheet" href="{{ "/css/poole.css" | absURL }}">
-  <link rel="stylesheet" href="{{ "/css/hyde.css" | absURL }}">
-  <link rel="stylesheet" href="{{ "/css/poole-overrides.css" | absURL }}">
-  <link rel="stylesheet" href="{{ "/css/hyde-overrides.css" | absURL }}">
-  <link rel="stylesheet" href="{{ "/css/hyde-x.css" | absURL }}">
-  {{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ "/css/highlight/" | absURL }}{{ .Site.Params.highlight }}.css">{{ end }}
+  <link rel="stylesheet" href="{{ "css/poole.css" | absURL }}">
+  <link rel="stylesheet" href="{{ "css/hyde.css" | absURL }}">
+  <link rel="stylesheet" href="{{ "css/poole-overrides.css" | absURL }}">
+  <link rel="stylesheet" href="{{ "css/hyde-overrides.css" | absURL }}">
+  <link rel="stylesheet" href="{{ "css/hyde-x.css" | absURL }}">
+  {{ if isset .Site.Params "highlight" }}<link rel="stylesheet" href="{{ "css/highlight/" | absURL }}{{ .Site.Params.highlight }}.css">{{ end }}
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700|Abril+Fatface">
   <link rel="stylesheet" href="//maxcdn.bootstrapcdn.com/font-awesome/4.3.0/css/font-awesome.min.css">
   {{ with .Site.Params.customCSS }}<link rel="stylesheet" href="{{ . }}">{{ end }}
 
   <!-- Icons -->
-  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ "/touch-icon-144-precomposed.png" | absURL }}">
-  <link href="{{ "/favicon.png" | absURL }}" rel="icon">
+  <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ "touch-icon-144-precomposed.png" | absURL }}">
+  <link href="{{ "favicon.png" | absURL }}" rel="icon">
 
   <!-- RSS -->
   {{ $siteTitle := .Site.Title }}

--- a/layouts/partials/sidebar.html
+++ b/layouts/partials/sidebar.html
@@ -10,7 +10,7 @@
     </div>
 
     <ul class="sidebar-nav">
-      <li class="sidebar-nav-item"><a href="{{ "/" | absURL }}">{{ if isset .Site.Params "home"}}{{ .Site.Params.home }}{{ else }}Blog{{ end }}</a></li>
+      <li class="sidebar-nav-item"><a href="{{ "" | absURL }}">{{ if isset .Site.Params "home"}}{{ .Site.Params.home }}{{ else }}Blog{{ end }}</a></li>
       {{ range .Site.Menus.main }}
       <li class="sidebar-nav-item">{{ .Pre }}<a href="{{ .URL | absURL }}">{{ .Name }}</a></li>
       {{end}}
@@ -26,7 +26,7 @@
       {{ with .Site.Params.facebook }}<a href="{{ . }}"><i class="fa fa-facebook-square fa-3x"></i></a>{{ end }}
       {{ with .Site.Params.twitter }}<a href="{{ . }}"><i class="fa fa-twitter-square fa-3x"></i></a>{{ end }}
       {{ with .Site.Params.youtube }}<a href="{{ . }}"><i class="fa fa-youtube-square fa-3x"></i></a>{{ end }}
-      {{ if .Site.Params.rss }}<a href="{{ "/index.xml" | absURL }}" type="application/rss+xml"><i class="fa fa-rss-square fa-3x"></i></a>{{ end }}
+      {{ if .Site.Params.rss }}<a href="{{ "index.xml" | absURL }}" type="application/rss+xml"><i class="fa fa-rss-square fa-3x"></i></a>{{ end }}
       </li>
     </ul>
 
@@ -35,7 +35,7 @@
       (function(id){
         var s = document.getElementById(id);
         var f = document.createElement('iframe');
-        f.src = '//api.flattr.com/button/view/?uid={{ .Site.Params.flattr }}&button=compact&url={{ "/" | absURL }}&title={{ .Site.Title }}';
+        f.src = '//api.flattr.com/button/view/?uid={{ .Site.Params.flattr }}&button=compact&url={{ "" | absURL }}&title={{ .Site.Title }}';
         f.title = 'Flattr';
         f.height = 20;
         f.width = 110;

--- a/layouts/partials/sidebar/footer.html
+++ b/layouts/partials/sidebar/footer.html
@@ -1,2 +1,2 @@
-<p>Copyright &copy; {{ now.Format "2006" }} <a href="{{ "/license/" | absURL }}">License</a><br/>
+<p>Copyright &copy; {{ now.Format "2006" }} <a href="{{ "license/" | absURL }}">License</a><br/>
        Powered by <a href="http://gohugo.io">Hugo</a> and <a href="https://github.com/zyro/hyde-x">Hyde-X</a></p>

--- a/layouts/post/single.html
+++ b/layouts/post/single.html
@@ -5,7 +5,7 @@
     <span class="post-date">{{ .Date.Format "Jan 2, 2006" }}{{ if not .Site.Params.hideReadingTime }} &middot; {{ .ReadingTime }} minute read{{ end }}{{ if .Site.DisqusShortname }} &middot; <a href="{{ .Permalink }}#disqus_thread">Comments</a>{{ end }}
     {{ if isset .Params "categories" }}
     <br/>
-    {{ range .Params.categories }}<a class="label" href="{{ "/categories/" | absURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
+    {{ range .Params.categories }}<a class="label" href="{{ "categories/" | absURL }}{{ . | urlize }}">{{ . }}</a>{{ end }}
     {{ end }}</span>
     {{ .Content }}
   </div>


### PR DESCRIPTION
absURL was used with a leading "/" resulting in broken generated links if the blog is hosted in a subfolder.

baseURL = "https://example.com/myblog"

The result of the generated links becomes "https://example.com/css/hyde.css" instead of "https://example.com/myblog/css/hyde.css"