### PR TITLE
Allow for descriptions to contain markdown content

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -15,7 +15,7 @@
       {{ if eq .Site.Params.truncate false }}
       {{ .Content }}
       {{ else if .Description }}
-      <p>{{ .Description }}</p>
+      <p>{{ .Description | markdownify}}</p>
       <a href="{{ .Permalink }}">Read On &rarr;</a>
       {{ else }}
       {{ .Summary }}


### PR DESCRIPTION
This allows for descriptions to contain markdown. Provides a little more flexibility when describing the content of a post to your audience.