### PR TITLE
Fix front page post list for hugo v. > 0.57.0

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,7 +1,7 @@
 {{ partial "head.html" . }}
 <div class="content container">
   <div class="posts">
-    {{ $paginator := .Paginate (where .Data.Pages "Type" "post") }}
+    {{ $paginator := .Paginate (where .Site.RegularPages "Type" "post") }}
     {{ range $paginator.Pages }}
     <div class="post">
       <h1 class="post-title">


### PR DESCRIPTION
From Hugo version 0.57.0 (as far as I can tell), the front page template no longer shows a list of all posts with short summary, but a single link named "Posts". See the Notes here: https://github.com/gohugoio/hugo/releases/tag/v0.57.0

This very basic pull request updates the index page to match the new Paginator behaviour. I'm sharing here for any other users of this theme!